### PR TITLE
freeing 'inventory' on node destruction

### DIFF
--- a/src/entities/player.gd
+++ b/src/entities/player.gd
@@ -23,6 +23,10 @@ var inventory = preload("res://data/scenes/inventory.tscn").instance()
 func _init().(150, 100, "model/AnimationPlayer"):
 	pass
 
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		inventory.free()
+
 func set_equipment(model, bone, name=null):
 	var skel = get_node("model/Armature/Skeleton")
 	for node in skel.get_children():

--- a/src/interact/chest.gd
+++ b/src/interact/chest.gd
@@ -11,6 +11,10 @@ var player = null
 func _ready():
 	inventory.init([], 100)
 
+func _notification(what):
+	if what == NOTIFICATION_PREDELETE:
+		inventory.free()
+
 func interact(player):
 	if self.player == null:
 		self.player = player


### PR DESCRIPTION
Inventories were not deleted upon quitting to main menu. Now they are.